### PR TITLE
Fix error https:https...

### DIFF
--- a/tle/cogs/handles.py
+++ b/tle/cogs/handles.py
@@ -220,7 +220,7 @@ def _make_profile_embed(member, user, *, mode):
         embed = discord.Embed(description=desc, color=user.rank.color_embed)
         embed.add_field(name='Rating', value=user.rating, inline=True)
         embed.add_field(name='Rank', value=user.rank.title, inline=True)
-    embed.set_thumbnail(url=f'https:{user.titlePhoto}')
+    embed.set_thumbnail(url=f'{user.titlePhoto}')
     return embed
 
 


### PR DESCRIPTION
In embed.thumbnail.url: Scheme "https:https" is not supported. Scheme must be one of ('http', 'https').